### PR TITLE
Adds new scanner api for tailing logs

### DIFF
--- a/firehose_scanner.go
+++ b/firehose_scanner.go
@@ -1,0 +1,55 @@
+package noaa
+
+import (
+	"github.com/cloudfoundry/noaa/events"
+	"io"
+	"sync"
+)
+
+type FirehoseScanner struct {
+	outputChan chan *events.Envelope
+	consumer   *Consumer
+	err        error
+	event      *events.Envelope
+	syncRoot   *sync.RWMutex
+	onceErr    *sync.Once
+}
+
+func newFirehoseScanner(appGuid, authToken string, consumer *Consumer) *FirehoseScanner {
+	outputChan := make(chan *events.Envelope)
+	scanner := &FirehoseScanner{
+		outputChan: outputChan,
+		consumer:   consumer,
+		syncRoot:   &sync.RWMutex{},
+		onceErr:    &sync.Once{},
+	}
+
+	go scanner.startScanning(appGuid, authToken, outputChan)
+	return scanner
+}
+
+func (s *FirehoseScanner) Scan() (*events.Envelope, error) {
+	event, ok := <-s.outputChan
+	if ok {
+		return event, nil
+	}
+	return nil, s.setError(io.EOF)
+}
+
+func (s *FirehoseScanner) Close() {
+	s.setError(io.EOF)
+}
+
+func (s *FirehoseScanner) setError(err error) error {
+	s.onceErr.Do(func() {
+		s.err = err
+		close(s.outputChan)
+	})
+	return s.err
+}
+
+func (s *FirehoseScanner) startScanning(subscriptionId, authToken string, outputChan chan<- *events.Envelope) {
+	err := s.consumer.FirehoseWithoutReconnect(subscriptionId, authToken, outputChan)
+	s.setError(err)
+	s.Close()
+}

--- a/firehose_scanner_test.go
+++ b/firehose_scanner_test.go
@@ -1,0 +1,72 @@
+package noaa_test
+
+import (
+	"github.com/cloudfoundry/noaa"
+
+	"github.com/cloudfoundry/loggregatorlib/loggertesthelper"
+	"github.com/cloudfoundry/loggregatorlib/server/handlers"
+	"github.com/cloudfoundry/noaa/events"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+var _ = Describe("FirehoseScanner", func() {
+	var (
+		fakeHandler          *FakeHandler
+		testServer           *httptest.Server
+		trafficControllerUrl string
+		subscriptionId       string
+	)
+
+	var startFakeTrafficController = func() {
+		fakeHandler = &FakeHandler{
+			InputChan: make(chan []byte, 10),
+			GenerateHandler: func(input chan []byte) http.Handler {
+				return handlers.NewWebsocketHandler(input, 100*time.Millisecond, loggertesthelper.Logger())
+			},
+		}
+
+		testServer = httptest.NewServer(fakeHandler)
+		trafficControllerUrl = "ws://" + testServer.Listener.Addr().String()
+		subscriptionId = "some-id"
+	}
+
+	BeforeEach(func() {
+		startFakeTrafficController()
+	})
+
+	It("should return data until the connection is closed", func(done Done) {
+		count := 50
+		defer close(done)
+
+		scanner := noaa.NewStreamScannerFactory(trafficControllerUrl, nil)
+		firehose := scanner.Firehose("some-id", "some-token")
+
+		go putDataOntoTheLine(count, fakeHandler)
+
+		resultsChan := make(chan string, 5)
+		errChan := make(chan error, 5)
+		for i := 0; i < 5; i++ {
+			go func() {
+				var event *events.Envelope
+				var err error
+				for event, err = firehose.Scan(); err == nil; event, err = firehose.Scan() {
+					resultsChan <- string(event.GetLogMessage().GetMessage())
+				}
+				errChan <- err
+			}()
+		}
+
+		expectedResults := buildExpectedSlice(count)
+		results := fetchResults(count, resultsChan)
+		Expect(results).To(ConsistOf(expectedResults))
+		firehose.Close()
+
+		for i := 0; i < 5; i++ {
+			Eventually(errChan).Should(Receive())
+		}
+	})
+})

--- a/stream_scanner_factory.go
+++ b/stream_scanner_factory.go
@@ -1,0 +1,19 @@
+package noaa
+
+import (
+	"crypto/tls"
+)
+
+type StreamScanner struct {
+	consumer *Consumer
+}
+
+func NewStreamScannerFactory(trafficControllerUrl string, tlsConfig *tls.Config) *StreamScanner {
+	return &StreamScanner{
+		consumer: NewConsumer(trafficControllerUrl, tlsConfig, nil),
+	}
+}
+
+func (s *StreamScanner) TailLogs(appGuid, authToken string) *TailingLogsScanner {
+	return newTailingLogsScanner(appGuid, authToken, s.consumer)
+}

--- a/stream_scanner_factory.go
+++ b/stream_scanner_factory.go
@@ -17,3 +17,7 @@ func NewStreamScannerFactory(trafficControllerUrl string, tlsConfig *tls.Config)
 func (s *StreamScanner) TailLogs(appGuid, authToken string) *TailingLogsScanner {
 	return newTailingLogsScanner(appGuid, authToken, s.consumer)
 }
+
+func (s *StreamScanner) Firehose(subscriptionId, authToken string) *FirehoseScanner {
+	return newFirehoseScanner(subscriptionId, authToken, s.consumer)
+}

--- a/tailing_logs_scanner.go
+++ b/tailing_logs_scanner.go
@@ -1,0 +1,55 @@
+package noaa
+
+import (
+	"github.com/cloudfoundry/noaa/events"
+	"io"
+	"sync"
+)
+
+type TailingLogsScanner struct {
+	outputChan chan *events.LogMessage
+	consumer   *Consumer
+	err        error
+	event      *events.LogMessage
+	syncRoot   *sync.RWMutex
+	onceErr    *sync.Once
+}
+
+func newTailingLogsScanner(appGuid, authToken string, consumer *Consumer) *TailingLogsScanner {
+	outputChan := make(chan *events.LogMessage)
+	scanner := &TailingLogsScanner{
+		outputChan: outputChan,
+		consumer:   consumer,
+		syncRoot:   &sync.RWMutex{},
+		onceErr:    &sync.Once{},
+	}
+
+	go scanner.startTailing(appGuid, authToken, outputChan)
+	return scanner
+}
+
+func (s *TailingLogsScanner) Scan() (*events.LogMessage, error) {
+	event, ok := <-s.outputChan
+	if ok {
+		return event, nil
+	}
+	return nil, s.setError(io.EOF)
+}
+
+func (s *TailingLogsScanner) Close() {
+	s.setError(io.EOF)
+}
+
+func (s *TailingLogsScanner) setError(err error) error {
+	s.onceErr.Do(func() {
+		s.err = err
+		close(s.outputChan)
+	})
+	return s.err
+}
+
+func (s *TailingLogsScanner) startTailing(appGuid, authToken string, outputChan chan<- *events.LogMessage) {
+	err := s.consumer.TailingLogsWithoutReconnect(appGuid, authToken, outputChan)
+	s.setError(err)
+	s.Close()
+}

--- a/tailing_logs_scanner_test.go
+++ b/tailing_logs_scanner_test.go
@@ -1,0 +1,96 @@
+package noaa_test
+
+import (
+	"github.com/cloudfoundry/noaa"
+
+	"github.com/cloudfoundry/loggregatorlib/loggertesthelper"
+	"github.com/cloudfoundry/loggregatorlib/server/handlers"
+	"github.com/cloudfoundry/noaa/events"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"time"
+)
+
+var _ = Describe("TailingLogsScanner", func() {
+	var (
+		fakeHandler          *FakeHandler
+		testServer           *httptest.Server
+		trafficControllerUrl string
+		appGuid              string
+	)
+
+	var startFakeTrafficController = func() {
+		fakeHandler = &FakeHandler{
+			InputChan: make(chan []byte, 10),
+			GenerateHandler: func(input chan []byte) http.Handler {
+				return handlers.NewWebsocketHandler(input, 100*time.Millisecond, loggertesthelper.Logger())
+			},
+		}
+
+		testServer = httptest.NewServer(fakeHandler)
+		trafficControllerUrl = "ws://" + testServer.Listener.Addr().String()
+		appGuid = "appGuidp-guid"
+	}
+
+	BeforeEach(func() {
+		startFakeTrafficController()
+	})
+
+	It("should return data until the connection is closed", func(done Done) {
+		count := 50
+		defer close(done)
+
+		scanner := noaa.NewStreamScannerFactory(trafficControllerUrl, nil)
+		tailer := scanner.TailLogs("some-guid", "some-token")
+
+		go putDataOntoTheLine(count, fakeHandler)
+
+		resultsChan := make(chan string, 5)
+		errChan := make(chan error, 5)
+		for i := 0; i < 5; i++ {
+			go func() {
+				var event *events.LogMessage
+				var err error
+				for event, err = tailer.Scan(); err == nil; event, err = tailer.Scan() {
+					resultsChan <- string(event.GetMessage())
+				}
+				errChan <- err
+			}()
+		}
+
+		expectedResults := buildExpectedSlice(count)
+		results := fetchResults(count, resultsChan)
+		Expect(results).To(ConsistOf(expectedResults))
+		tailer.Close()
+
+		for i := 0; i < 5; i++ {
+			Eventually(errChan).Should(Receive())
+		}
+	})
+})
+
+func buildExpectedSlice(count int) []string {
+	expectedResults := make([]string, 0)
+	for i := 0; i < count; i++ {
+		expectedResults = append(expectedResults, strconv.Itoa(i))
+	}
+	return expectedResults
+}
+
+func putDataOntoTheLine(count int, fakeHandler *FakeHandler) {
+	for i := 0; i < count; i++ {
+		fakeHandler.InputChan <- marshalMessage(createMessage(strconv.Itoa(i), 0))
+	}
+}
+
+func fetchResults(count int, resultsChan chan string) []string {
+	results := make([]string, 0)
+	for i := 0; i < count; i++ {
+		msg := <-resultsChan
+		results = append(results, msg)
+	}
+	return results
+}


### PR DESCRIPTION
I'm doing a pull request to see if anyone thinks this API looks better.  The API avoids exposing channels, but is still thread safe.  

It only does the TailingLogs, but would be very easy to implement the others if required.