### PR TITLE
Set consumer to open after connection goroutines are closed

### DIFF
--- a/consumer/async.go
+++ b/consumer/async.go
@@ -129,6 +129,12 @@ func (c *Consumer) close() {
 	c.closed = true
 }
 
+func (c *Consumer) open() {
+	c.closedLock.Lock()
+	defer c.closedLock.Unlock()
+	c.closed = false
+}
+
 func (c *Consumer) onConnectCallback() func() {
 	c.callbackLock.RLock()
 	defer c.callbackLock.RUnlock()
@@ -252,6 +258,7 @@ func (c *Consumer) retryAction(action func() error, errors chan<- error, retries
 
 	for ; reconnectAttempts <= retries; reconnectAttempts++ {
 		if c.Closed() {
+			c.open()
 			return
 		}
 

--- a/consumer/async_test.go
+++ b/consumer/async_test.go
@@ -369,6 +369,12 @@ var _ = Describe("Consumer (Asynchronous)", func() {
 			}
 		}, 20)
 
+		It("resets the closed flag to false after it is no longer needed", func() {
+			cnsmr.Close()
+			Eventually(cnsmr.Closed).Should(BeTrue())
+			Eventually(cnsmr.Closed).Should(BeFalse())
+		})
+
 		Context("with a failing handler", func() {
 			BeforeEach(func() {
 				fakeHandler.Fail = true


### PR DESCRIPTION
Signed-off-by: Jeff Pak jeffrey.pak@emc.com
