### PR TITLE
Make `consumer.Consumer` Handle Multiple Websocket Connections

### DIFF
--- a/consumer/async.go
+++ b/consumer/async.go
@@ -308,8 +308,9 @@ func (c *Consumer) establishWebsocketConnection(path string, authToken string) (
 		return ws, err
 	}
 
-	if err == nil && c.callback != nil {
-		c.callback()
+	callback := c.onConnectCallback()
+	if err == nil && callback != nil {
+		callback()
 	}
 
 	if err != nil {

--- a/consumer/async.go
+++ b/consumer/async.go
@@ -114,12 +114,6 @@ func (c *Consumer) Close() error {
 	return nil
 }
 
-// Closed is a legacy method that now returns false.  Consumers cannot be closed;
-// they will always be able to make more requests to the TrafficController.
-func (c *Consumer) Closed() bool {
-	return false
-}
-
 func (c *Consumer) SetIdleTimeout(idleTimeout time.Duration) {
 	c.idleTimeout = idleTimeout
 }

--- a/consumer/async.go
+++ b/consumer/async.go
@@ -129,6 +129,12 @@ func (c *Consumer) close() {
 	c.closed = true
 }
 
+func (c *Consumer) open() {
+	c.closedLock.Lock()
+	defer c.closedLock.Unlock()
+	c.closed = false
+}
+
 func (c *Consumer) onConnectCallback() func() {
 	c.callbackLock.RLock()
 	defer c.callbackLock.RUnlock()
@@ -252,6 +258,7 @@ func (c *Consumer) retryAction(action func() error, errors chan<- error, retries
 
 	for ; reconnectAttempts <= retries; reconnectAttempts++ {
 		if c.Closed() {
+			c.open()
 			return
 		}
 

--- a/consumer/async.go
+++ b/consumer/async.go
@@ -99,9 +99,6 @@ func (c *Consumer) SetOnConnectCallback(cb func()) {
 // Close terminates all previously opened websocket connections to the traffic
 // controller.  It will return an error if there are no open connections, or
 // if it has problems closing any connection.
-//
-// The consumer will mark itself closed once it is done, and will reopen the next
-// time a websocket connection is made.
 func (c *Consumer) Close() error {
 	c.connsLock.Lock()
 	defer c.connsLock.Unlock()

--- a/consumer/async.go
+++ b/consumer/async.go
@@ -212,17 +212,6 @@ func (c *Consumer) firehose(subID, authToken string, retries uint) (<-chan *even
 	return outputs, errors
 }
 
-func (c *Consumer) stream(streamPath string, authToken string, callback func(*events.Envelope)) error {
-	ws, err := c.establishWebsocketConnection(streamPath, authToken)
-	if err != nil {
-		return err
-	}
-	conn := c.newConn()
-	conn.setWebsocket(ws)
-
-	return c.listenForMessages(conn, callback)
-}
-
 func (c *Consumer) listenForMessages(conn *connection, callback func(*events.Envelope)) error {
 	if conn.Closed() {
 		return nil

--- a/consumer/async_test.go
+++ b/consumer/async_test.go
@@ -369,6 +369,12 @@ var _ = Describe("Consumer (Asynchronous)", func() {
 			}
 		}, 20)
 
+		It("resets the closed flag to false after it is no longer needed", func() {
+			cnsmr.Close()
+			Eventually(cnsmr.Closed).Should(BeTrue())
+			Eventually(cnsmr.Closed).Should(BeFalse())
+		})
+
 		Context("with a failing handler", func() {
 			BeforeEach(func() {
 				fakeHandler.Fail = true

--- a/consumer/async_test.go
+++ b/consumer/async_test.go
@@ -369,11 +369,6 @@ var _ = Describe("Consumer (Asynchronous)", func() {
 			}
 		}, 20)
 
-		It("resets the closed flag to false after it is no longer needed", func() {
-			cnsmr.Close()
-			Eventually(cnsmr.Closed).Should(BeFalse())
-		})
-
 		Context("with multiple connections", func() {
 			var (
 				moreLogMessages <-chan *events.LogMessage
@@ -390,7 +385,6 @@ var _ = Describe("Consumer (Asynchronous)", func() {
 				Eventually(errors).Should(BeClosed())
 				Eventually(moreLogMessages).Should(BeClosed())
 				Eventually(moreErrors).Should(BeClosed())
-				Eventually(cnsmr.Closed).Should(BeFalse())
 			})
 		})
 

--- a/consumer/async_test.go
+++ b/consumer/async_test.go
@@ -375,6 +375,26 @@ var _ = Describe("Consumer (Asynchronous)", func() {
 			Eventually(cnsmr.Closed).Should(BeFalse())
 		})
 
+		Context("with multiple connections", func() {
+			var (
+				moreLogMessages <-chan *events.LogMessage
+				moreErrors      <-chan error
+			)
+
+			JustBeforeEach(func() {
+				moreLogMessages, moreErrors = cnsmr.TailingLogs(appGuid, authToken)
+			})
+
+			It("closes all channels before reopening", func() {
+				cnsmr.Close()
+				Eventually(logMessages).Should(BeClosed())
+				Eventually(errors).Should(BeClosed())
+				Eventually(moreLogMessages).Should(BeClosed())
+				Eventually(moreErrors).Should(BeClosed())
+				Eventually(cnsmr.Closed).Should(BeFalse())
+			})
+		})
+
 		Context("with a failing handler", func() {
 			BeforeEach(func() {
 				fakeHandler.Fail = true

--- a/consumer/async_test.go
+++ b/consumer/async_test.go
@@ -371,7 +371,6 @@ var _ = Describe("Consumer (Asynchronous)", func() {
 
 		It("resets the closed flag to false after it is no longer needed", func() {
 			cnsmr.Close()
-			Eventually(cnsmr.Closed).Should(BeTrue())
 			Eventually(cnsmr.Closed).Should(BeFalse())
 		})
 
@@ -385,7 +384,7 @@ var _ = Describe("Consumer (Asynchronous)", func() {
 				moreLogMessages, moreErrors = cnsmr.TailingLogs(appGuid, authToken)
 			})
 
-			It("closes all channels before reopening", func() {
+			It("closes all channels", func() {
 				cnsmr.Close()
 				Eventually(logMessages).Should(BeClosed())
 				Eventually(errors).Should(BeClosed())
@@ -626,7 +625,7 @@ var _ = Describe("Consumer (Asynchronous)", func() {
 		Context("when a connection is not open", func() {
 			It("returns an error", func() {
 				err := cnsmr.Close()
-
+				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("connection does not exist"))
 			})
 		})
@@ -643,6 +642,7 @@ var _ = Describe("Consumer (Asynchronous)", func() {
 
 				Eventually(fakeHandler.WasCalled).Should(BeTrue())
 				connErr := cnsmr.Close()
+				Expect(connErr).To(HaveOccurred())
 				Expect(connErr.Error()).To(ContainSubstring("use of closed network connection"))
 
 				var err error

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -42,16 +42,15 @@ type DebugPrinter interface {
 type Consumer struct {
 	trafficControllerUrl string
 	idleTimeout          time.Duration
-	ws                   *websocket.Conn
 	callback             func()
 	callbackLock         sync.RWMutex
 	proxy                func(*http.Request) (*url.URL, error)
 	debugPrinter         DebugPrinter
-	conLock              sync.RWMutex
-	closed               bool
-	closedLock           sync.Mutex
 	client               *http.Client
 	dialer               websocket.Dialer
+
+	conns     []*connection
+	connsLock sync.Mutex
 }
 
 // New creates a new consumer to a traffic controller.

--- a/test_helpers/fake_handler.go
+++ b/test_helpers/fake_handler.go
@@ -60,9 +60,6 @@ func (fh *FakeHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Set("Content-Length", fh.ContentLen)
 	}
 
-	fh.Lock()
-	defer fh.Unlock()
-
 	if fh.Fail {
 		return
 	}

--- a/test_helpers/fake_handler.go
+++ b/test_helpers/fake_handler.go
@@ -64,6 +64,8 @@ func (fh *FakeHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	fh.RLock()
+	defer fh.RUnlock()
 	handler := fh.GenerateHandler(fh.InputChan)
 	handler.ServeHTTP(rw, r)
 }


### PR DESCRIPTION
These changes allow `consumer.Consumer` to manage a slice of connections.  Any connections created by the consumer will be closed when the consumer's `Close` method is called.