### PR TITLE
added tunable timeout to TailingLogs retries

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -47,7 +47,7 @@ type Consumer struct {
 	// minRetryDelay and maxRetryDelay must be the first words in this struct
 	// in order to be used atomically by 32-bit systems.
 	// https://golang.org/src/sync/atomic/doc.go?#L50
-	minRetryDelay, maxRetryDelay int64
+	minRetryDelay, maxRetryDelay, retryTimeout int64
 
 	trafficControllerUrl string
 	idleTimeout          time.Duration

--- a/errors/retry_timeout_error.go
+++ b/errors/retry_timeout_error.go
@@ -1,0 +1,15 @@
+package errors
+
+// RetryTimeoutError is encountered when retrying an operation times out.
+type RetryTimeoutError struct {
+}
+
+// NewRetryTimeoutError constructs a RetryTimeoutError from any error.
+func NewRetryTimeoutError() RetryTimeoutError {
+	return RetryTimeoutError{}
+}
+
+// Error implements error.
+func (e RetryTimeoutError) Error() string {
+	return "Retry has timed out. Please ask your Cloud Foundry Operator for support."
+}


### PR DESCRIPTION
- timeout defaults to unlimited
- configure the timeout with SetRetryTimeout
- sends RetryTimeoutError to the errors channel when timout has been
reached

Signed-off-by: Alex Melnik <aleksandr.s.melnik@hpe.com>