### PR TITLE
Allow recent path structure to be modified

### DIFF
--- a/consumer/async.go
+++ b/consumer/async.go
@@ -216,7 +216,7 @@ func (c *Consumer) runStream(appGuid, authToken string, retry bool) (<-chan *eve
 }
 
 func (c *Consumer) streamAppDataTo(conn *connection, appGuid, authToken string, callback func(*events.Envelope), errors chan<- error, retry bool) {
-	streamPath := fmt.Sprintf("/apps/%s/stream", appGuid)
+	streamPath := c.streamPathBuilder(appGuid)
 	if retry {
 		c.retryAction(c.listenAction(conn, streamPath, authToken, callback), errors)
 		return

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -45,6 +45,7 @@ func (nullDebugPrinter) Print(title, body string) {
 }
 
 type RecentPathBuilder func(trafficControllerUrl *url.URL, appGuid string, endpoint string) string
+type StreamPathBuilder func(appGuid string) string
 
 // Consumer represents the actions that can be performed against trafficcontroller.
 // See sync.go and async.go for trafficcontroller access methods.
@@ -70,6 +71,7 @@ type Consumer struct {
 	tokenRefresher TokenRefresher
 
 	recentPathBuilder RecentPathBuilder
+	streamPathBuilder StreamPathBuilder
 }
 
 // New creates a new consumer to a trafficcontroller.
@@ -99,6 +101,7 @@ func New(trafficControllerUrl string, tlsConfig *tls.Config, proxy func(*http.Re
 			TLSClientConfig:  tlsConfig,
 		},
 		recentPathBuilder: defaultRecentPathBuilder,
+		streamPathBuilder: defaultStreamPathBuilder,
 	}
 }
 
@@ -114,6 +117,14 @@ func defaultRecentPathBuilder(trafficControllerUrl *url.URL, appGuid string, end
 
 func (c *Consumer) SetRecentPathBuilder(b RecentPathBuilder) {
 	c.recentPathBuilder = b
+}
+
+func defaultStreamPathBuilder(appGuid string) string {
+	return fmt.Sprintf("/apps/%s/stream", appGuid)
+}
+
+func (c *Consumer) SetStreamPathBuilder(b StreamPathBuilder) {
+	c.streamPathBuilder = b
 }
 
 type httpError struct {

--- a/consumer/sync.go
+++ b/consumer/sync.go
@@ -72,12 +72,7 @@ func (c *Consumer) readTC(appGuid string, authToken string, endpoint string) ([]
 		return nil, err
 	}
 
-	scheme := "https"
-	if trafficControllerUrl.Scheme == "ws" {
-		scheme = "http"
-	}
-
-	recentPath := fmt.Sprintf("%s://%s/apps/%s/%s", scheme, trafficControllerUrl.Host, appGuid, endpoint)
+	recentPath := c.recentPathBuilder(trafficControllerUrl, appGuid, endpoint)
 
 	resp, err := c.requestTC(recentPath, authToken)
 	if err != nil {

--- a/consumer/sync_test.go
+++ b/consumer/sync_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cloudfoundry/noaa/test_helpers"
 	"github.com/cloudfoundry/sonde-go/events"
 
+	"net/url"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -26,6 +28,8 @@ var _ = Describe("Consumer (Synchronous)", func() {
 		appGuid        string
 		authToken      string
 		messagesToSend chan []byte
+
+		recentPathBuilder consumer.RecentPathBuilder
 	)
 
 	BeforeEach(func() {
@@ -37,10 +41,16 @@ var _ = Describe("Consumer (Synchronous)", func() {
 		appGuid = ""
 		authToken = ""
 		messagesToSend = make(chan []byte, 256)
+
+		recentPathBuilder = nil
 	})
 
 	JustBeforeEach(func() {
 		cnsmr = consumer.New(trafficControllerURL, tlsSettings, nil)
+
+		if recentPathBuilder != nil {
+			cnsmr.SetRecentPathBuilder(recentPathBuilder)
+		}
 	})
 
 	AfterEach(func() {
@@ -199,6 +209,30 @@ var _ = Describe("Consumer (Synchronous)", func() {
 				Expect(recentError).To(HaveOccurred())
 				Expect(recentError.Error()).To(ContainSubstring("You are not authorized. Helpful message"))
 				Expect(recentError).To(BeAssignableToTypeOf(&errors.UnauthorizedError{}))
+			})
+		})
+
+		Context("when a recent path builder is provided", func() {
+			var pathUsed bool
+
+			BeforeEach(func() {
+				pathUsed = false
+				recentPathBuilder = func(trafficControllerUrl *url.URL, appGuid string, endpoint string) string {
+					return fmt.Sprintf("http://%s/logs/%s/%s", trafficControllerUrl.Host, endpoint, appGuid)
+				}
+
+				serverMux := http.NewServeMux()
+				serverMux.HandleFunc("/logs/recentlogs/appGuid", func(resp http.ResponseWriter, req *http.Request) {
+					pathUsed = true
+					resp.WriteHeader(http.StatusUnauthorized) // Avoid having to do more
+				})
+				testServer = httptest.NewServer(serverMux)
+				trafficControllerURL = "ws://" + testServer.Listener.Addr().String()
+			})
+
+			It("uses the path provided by the recent path builder", func() {
+				Expect(pathUsed).To(BeTrue())
+				Expect(recentError).To(MatchError((&errors.UnauthorizedError{}).Error()))
 			})
 		})
 	})


### PR DESCRIPTION
This enables noaa to be used with doppler-style endpoints with a different
structure of recent path URL from the default.

Adopted suggestion of RecentPathBuilder function type from @jasonkeene -
thanks!

This addresses https://github.com/cloudfoundry/noaa/issues/33.